### PR TITLE
Added the ability to deactivate touch / mouse events

### DIFF
--- a/src/js/owl.carousel.js
+++ b/src/js/owl.carousel.js
@@ -697,7 +697,7 @@
 	Owl.prototype.onDragStart = function(event) {
 		var stage = null;
 
-		if (event.which === 3) {
+		if (event.which === 3 || this._states.tags.disabled) {
 			return;
 		}
 
@@ -763,7 +763,7 @@
 			delta = this.difference(this._drag.pointer, this.pointer(event)),
 			stage = this.difference(this._drag.stage.start, delta);
 
-		if (!this.is('dragging')) {
+		if (!this.is('dragging') || this._states.tags.disabled) {
 			return;
 		}
 
@@ -1609,6 +1609,15 @@
 		};
 	};
 
+  /**
+   * Sets the state of events in the app
+   * @protected
+   * @param {Boolean} isDisabled - Sets whether events are disabled or not
+   */
+  Owl.prototype.setEventsState = function (isDisabled) {
+    this._states.tags.disabled = isDisabled;
+  };
+
 	/**
 	 * The jQuery Plugin for the Owl Carousel
 	 * @todo Navigation plugin `next` and `prev`
@@ -1626,7 +1635,7 @@
 				$this.data('owl.carousel', data);
 
 				$.each([
-					'next', 'prev', 'to', 'destroy', 'refresh', 'replace', 'add', 'remove'
+					'next', 'prev', 'to', 'destroy', 'refresh', 'replace', 'add', 'remove', 'setEventsState'
 				], function(i, event) {
 					data.register({ type: Owl.Type.Event, name: event });
 					data.$element.on(event + '.owl.carousel.core', $.proxy(function(e) {

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,4 +1,4 @@
-@mixin transition($prop, $time, $easing){
+@mixin owlTransition($prop, $time, $easing){
 	-webkit-transition: $prop $time $easing;
 	-moz-transition: $prop $time $easing;
 	-ms-transition: $prop $time $easing;
@@ -6,13 +6,13 @@
 	transition: $prop $time $easing;
 }
 
-@mixin rounded($value){
+@mixin owlRounded($value){
 	-webkit-border-radius: $value;
 	-moz-border-radius: $value;
 	border-radius: $value;
 }
 
-@mixin transform($prop){
+@mixin owlTransform($prop){
 	-webkit-transition: $prop;
 	-moz-transition: $prop;
 	-ms-transition: $prop;

--- a/src/scss/_theme.scss
+++ b/src/scss/_theme.scss
@@ -14,7 +14,7 @@
 			background: $nav-background;
 			display: inline-block;
 			cursor: pointer;
-			@include rounded($nav-rounded);
+			@include owlRounded($nav-rounded);
 
 			&:hover {
 				background: $nav-background-hover;
@@ -48,8 +48,8 @@
 				background: $dot-background;
 				display: block;
 				-webkit-backface-visibility: visible;
-				@include transition(opacity, 200ms, ease);
-				@include rounded($dot-rounded);
+				@include owlTransition(opacity, 200ms, ease);
+				@include owlRounded($dot-rounded);
 			}
 
 			&.active,

--- a/src/scss/owl.autoheight.scss
+++ b/src/scss/owl.autoheight.scss
@@ -5,5 +5,5 @@
 @import 'mixins';
 
 .owl-height {
-	@include transition(height, 500ms, ease-in-out)
+	@include owlTransition(height, 500ms, ease-in-out)
 }

--- a/src/scss/owl.lazyload.scss
+++ b/src/scss/owl.lazyload.scss
@@ -8,7 +8,7 @@
 	.owl-item {
 		.owl-lazy {
   			opacity: 0;
-  			@include transition(opacity, 400ms, ease);
+  			@include owlTransition(opacity, 400ms, ease);
   		}
 		img{
 			transform-style: preserve-3d;

--- a/src/scss/owl.video.scss
+++ b/src/scss/owl.video.scss
@@ -22,10 +22,10 @@
 		cursor: pointer;
 		z-index: 1;
 		-webkit-backface-visibility: hidden;
-		@include transition(scale, 100ms, ease);
+		@include owlTransition(scale, 100ms, ease);
 	}
 	.owl-video-play-icon:hover {
-		@include transform(scale(1.3, 1.3));
+		@include owlTransform(scale(1.3, 1.3));
 	}
 	.owl-video-playing .owl-video-tn,
 	.owl-video-playing .owl-video-play-icon {
@@ -40,7 +40,7 @@
 		-moz-background-size: contain;
 		-o-background-size: contain;
 		background-size: contain;
-		@include transition(opacity, 400ms, ease);
+		@include owlTransition(opacity, 400ms, ease);
 	}
 	.owl-video-frame {
 		position: relative;


### PR DESCRIPTION
- Useful for the scenario where the carousel has elements with touch / mouse events. Turning off the carousel events prevents the two from competing for control. I understand that this is probably an edge case and that most people aren't using the carousel for this, but we are and it would be much appreciated if this could make its way in.