### PR TITLE
change instances of .andSelf to .addBack to comply with the jquery 1.9+ 

### DIFF
--- a/src/css/owl.animate.css
+++ b/src/css/owl.animate.css
@@ -27,6 +27,7 @@
     opacity: 0;
   }
 }
+
 @keyframes fadeOut {
   0% {
     opacity: 1;

--- a/src/js/owl.hash.js
+++ b/src/js/owl.hash.js
@@ -46,7 +46,7 @@
 			}, this),
 			'prepared.owl.carousel': $.proxy(function(e) {
 				if (e.namespace) {
-					var hash = $(e.content).find('[data-hash]').andSelf('[data-hash]').attr('data-hash');
+					var hash = $(e.content).find('[data-hash]').addBack('[data-hash]').attr('data-hash');
 
 					if (!hash) {
 						return;

--- a/src/js/owl.navigation.js
+++ b/src/js/owl.navigation.js
@@ -74,7 +74,7 @@
 			'prepared.owl.carousel': $.proxy(function(e) {
 				if (e.namespace && this._core.settings.dotsData) {
 					this._templates.push('<div class="' + this._core.settings.dotClass + '">' +
-						$(e.content).find('[data-dot]').andSelf('[data-dot]').attr('data-dot') + '</div>');
+						$(e.content).find('[data-dot]').addBack('[data-dot]').attr('data-dot') + '</div>');
 				}
 			}, this),
 			'added.owl.carousel': $.proxy(function(e) {


### PR DESCRIPTION
This is not a pull to formally introduce jquery 1.9+ support, however the only current blocker seems to be complying with this deprecation.  This should change no functionality of implementation of the api.

See http://jquery.com/upgrade-guide/1.9/#addback-selector-replaces-andself- for more details