### PR TITLE
Updates support email to smashing boxes opensource email.

### DIFF
--- a/docs_src/templates/pages/docs/started-faq.hbs
+++ b/docs_src/templates/pages/docs/started-faq.hbs
@@ -43,7 +43,7 @@ Yes! Go to [Github]({{ pkg.bugs.url }}) issues page and ask for a feature.
 ------
 #### I need help!
 
-First visit [Github]({{ pkg.bugs.url }}), then look again at documentation and demos. Finally if you’re still struggling send me an email: <owl@owlgraphic.com>. Don't forget to add [jsfiddle](http://jsfiddle.net/) or a link to your demo/example website!
+First visit [Github]({{ pkg.bugs.url }}), then look again at documentation and demos. Finally, if you’re still struggling, send us an email: <opensource@smashingboxes.com>. Don't forget to add [jsfiddle](http://jsfiddle.net/) or a link to your demo/example website!
 
 ------
 #### Does it have infinity scroll/circle/loop slides?

--- a/docs_src/templates/pages/docs/support-contact.hbs
+++ b/docs_src/templates/pages/docs/support-contact.hbs
@@ -14,10 +14,10 @@ tags:
 ## Contact
 ------
 
-If you have any questions please contact me via mail <owl@owlgraphic.com> or catch me on [Twitter](https://twitter.com/OwlFonk). If you are looking for help then the best place to ask a question is [Github]({{ pkg.bugs.url }}). Also don't forget to add a [jsfiddle](http://jsfiddle.net/) or a link to your demo/example website!
+If you have any questions please contact us via email <opensource@smashingboxes.com>. If you are looking for help then the best place to ask a question is [Github]({{ pkg.bugs.url }}). Also don't forget to add a [jsfiddle](http://jsfiddle.net/) or a link to your demo/example website!
 
-### Report a bug 
+### Report a bug
 
 Please use [Github]({{ pkg.bugs.url }}) to report bugs.
 
-{{/markdown }} 
+{{/markdown }}

--- a/docs_src/templates/pages/docs/support-contributing.hbs
+++ b/docs_src/templates/pages/docs/support-contributing.hbs
@@ -14,7 +14,7 @@ tags:
 ## Contributing
 
 
-> This project is hosted by Bartosz Wojciechowski but so many awesome contributors have had a big impact on the code. Thanks to all the amazing people who spent hours helping me with the development and teaching me new tricks!
+> This project is hosted by Smashing Boxes but so many awesome contributors have had a big impact on the code. Thanks to all the amazing people who spent hours helping me with the development and teaching me new tricks!
 
 If you are looking to support Owl Carousel with your amazing ideas (or just fix some nasty bugs) then go to [Github]({{ pkg.homepage }}) and fork the project.
 
@@ -59,4 +59,4 @@ Now you are ready to make some cool updates by yourself. Owl project is in `src`
 > Happy Coding
 
 
-{{/markdown }} 
+{{/markdown }}

--- a/package.json
+++ b/package.json
@@ -2,19 +2,19 @@
   "name": "owl.carousel",
   "description": "Touch enabled jQuery plugin that lets you create beautiful responsive carousel slider.",
   "version": "2.0.0-beta.2.4",
-  "homepage": "https://github.com/OwlFonk/OwlCarousel2",
+  "homepage": "https://github.com/smashingboxes/OwlCarousel2",
   "author": {
-    "name": "Bartosz Wojciechowski",
-    "email": "owl@owlgraphic.com",
+    "name": "Smashing Boxes",
+    "email": "opensource@smashingboxes.com",
     "url": "http://owlcarousel.owlgraphic.com"
   },
   "license": {
     "type": "MIT",
-    "url": "https://github.com/OwlFonk/OwlCarousel2/blob/master/LICENSE"
+    "url": "https://github.com/smashingboxes/OwlCarousel2/blob/master/LICENSE"
   },
   "bugs": {
-    "url": "http://github.com/OwlFonk/OwlCarousel2/issues",
-    "email": "owl@owlgraphic.com"
+    "url": "http://github.com/smashingboxes/OwlCarousel2/issues",
+    "email": "opensource@smashingboxes.com"
   },
   "devDependencies": {
     "assemble": "~0.4.37",
@@ -33,7 +33,7 @@
     "grunt-contrib-qunit": ">=0.2.1",
     "load-grunt-tasks": "^0.4.0",
     "pretty": "^0.1.2"
-   
+
   },
   "engines": {
     "node": "~0.10.28"


### PR DESCRIPTION
# What changed ?

* Updates email address to Smashing Boxes support email, opensource@smashingboxes.com.
* Updates `package.json` to point to smashingboxes/OwlCarousel2 rather than OwlFonk/OwlCarousel2.