### PR TITLE
Add details about Owl Carousel v1.0 to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,11 @@ $(document).ready(function(){
 });
 ```
 > See [demos](http://owlcarousel.owlgraphic.com/demos/demos.html) for customisation and options usage.
+
+### Using an earlier version?
+
+If you are using Owl Carousel v1.0, you can find the documentation [here](http://owlgraphic.com/owlcarousel/)
+
+This is the Github repository: [OwlFonk/OwlCarousel](https://github.com/OwlFonk/OwlCarousel)
+
+And this is the zipped plugin: [Owl Carousel v1.0](http://owlgraphic.com/owlcarousel/owl.carousel.zip)


### PR DESCRIPTION
Avoid confusions as in #840 

As there are two versions of this plugin, and it is **very easy to get confused** as to which version you are using, a mention of the earlier version in this README will speed up the debugging process!