### PR TITLE
Build: Adds blanket.js to provide test coverage information at build time (Ref #906)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -131,7 +131,16 @@ module.exports = function(grunt) {
 			},
 
 			qunit: {
-				dist: [ 'test/*.html' ]
+				dist: [ 'test/index.html' ]
+			},
+
+			blanket_qunit: {
+				dist: {
+					options: {
+						urls: [ 'test/index.html?coverage&gruntReport' ],
+						threshold: 0
+					}
+				}
 			},
 
 			jscs: {
@@ -248,7 +257,6 @@ module.exports = function(grunt) {
 				},
 				js: {
 					files: [ 'src/**/*.js' ],
-
 					tasks: [ 'jscs:dist', 'jshint:dist', 'qunit:dist', 'concat:dist', 'uglify:dist', 'usebanner:dist', 'copy:distToDocs', 'copy:srcToDocs' ]
 				},
 				helpersDocs: {
@@ -292,7 +300,7 @@ module.exports = function(grunt) {
 
 	grunt.registerTask('docs', [ 'dist', 'clean:docs', 'assemble', 'sass:docs', 'copy:docsAssets', 'copy:distToDocs', 'zip' ]);
 
-	grunt.registerTask('test', [ 'jshint:dist', 'qunit:dist' ]);
+	grunt.registerTask('test', [ 'jshint:dist', 'qunit:dist', 'blanket_qunit:dist' ]);
 
 	grunt.registerTask('default', [ 'dist', 'docs', 'test' ]);
 

--- a/package.json
+++ b/package.json
@@ -21,9 +21,11 @@
   },
   "devDependencies": {
     "assemble": "~0.4.37",
+    "blanket": "^1.1.7",
     "foundation-sites": "~5.5.2",
     "grunt": "~0.4.5",
     "grunt-banner": "^0.4.0",
+    "grunt-blanket-qunit": "^0.2.0",
     "grunt-contrib-clean": "~0.6.0",
     "grunt-contrib-compress": "~0.13.0",
     "grunt-contrib-concat": "~0.5.1",

--- a/test/index.html
+++ b/test/index.html
@@ -10,9 +10,15 @@
 
 		<script src="../node_modules/jquery/dist/jquery.js"></script>
 		<script src="../node_modules/qunitjs/qunit/qunit.js"></script>
+		<script src="../node_modules/blanket/dist/qunit/blanket.js"></script>
+		<script>
+			if (location.href.match(/(\?|&)gruntReport($|&|=)/)) {
+				blanket.options("reporter", "../node_modules/grunt-blanket-qunit/reporter/grunt-reporter.js");
+			}
+		</script>
 
-		<script src="../src/js/owl.carousel.js"></script>
-		<script src="../src/js/owl.support.js"></script>
+		<script src="../src/js/owl.carousel.js" data-cover></script>
+		<script src="../src/js/owl.support.js" data-cover></script>
 		<script src="unit/core.js"></script>
 	</head>
 	<body>


### PR DESCRIPTION
Adds test coverage information at build time. By default, when running grunt, it will only show the test coverage percentage if a file falls below the threshold.  If grunt is run with the `--verbose` flag, it will show the coverage percentage for every file that is tested.

At the moment, the pass threshold is set to 0%. I don't think our test coverage is robust enough at the moment to be failing builds because there aren't enough tests (the support module is at 100% and the main module is at 61%, but all other modules are 0%).