### PR TITLE
Fix syntax error in strict mode

### DIFF
--- a/src/js/owl.autoheight.js
+++ b/src/js/owl.autoheight.js
@@ -65,7 +65,7 @@
 	AutoHeight.prototype.update = function() {
 		var start = this._core._current,
 			end = start + this._core.settings.items,
-			visible = this._core.$stage.children().toArray().slice(start, end);
+			visible = this._core.$stage.children().toArray().slice(start, end),
 			heights = [],
 			maxheight = 0;
 


### PR DESCRIPTION
It simply threw an error when we use ``autoHeight`` because ``height`` is not defined