### PR TITLE
Slider showing part of next image in active slider #966

### DIFF
--- a/src/js/owl.carousel.js
+++ b/src/js/owl.carousel.js
@@ -261,7 +261,7 @@
 	Owl.Workers = [ {
 		filter: [ 'width', 'settings' ],
 		run: function() {
-			this._width = this.$element[0].getBoundingClientRect().width;
+			this._width = this.$element[0].getBoundingClientRect().width || this.$element.width();
 		}
 	}, {
 		filter: [ 'width', 'items', 'settings' ],

--- a/src/js/owl.carousel.js
+++ b/src/js/owl.carousel.js
@@ -261,7 +261,7 @@
 	Owl.Workers = [ {
 		filter: [ 'width', 'settings' ],
 		run: function() {
-			this._width = this.$element.width();
+			this._width = this.$element[0].getBoundingClientRect().width;
 		}
 	}, {
 		filter: [ 'width', 'items', 'settings' ],


### PR DESCRIPTION
.widh() returns smaller number if browser render fractional values, so there can be a one pixel of the next image visible.

.getBoundingClientRect() will solve this problem as it returns real size.