### PR TITLE
Only wrap item in container if it does not already have one.

### DIFF
--- a/src/js/owl.carousel.js
+++ b/src/js/owl.carousel.js
@@ -549,8 +549,11 @@
 		var event = this.trigger('prepare', { content: item });
 
 		if (!event.data) {
-			event.data = $('<' + this.settings.itemElement + '/>')
-				.addClass(this.options.itemClass).append(item)
+            if (!$(item).is(this.settings.itemElement + '.' + this.options.itemClass)) {
+                item = $('<' + this.settings.itemElement + '/>')
+                    .addClass(this.options.itemClass).append(item);
+            }
+			event.data = item;
 		}
 
 		this.trigger('prepared', { content: event.data });


### PR DESCRIPTION
This change allows removing and adding items with their container, preventing owl from nesting owl-item nodes.